### PR TITLE
[Bugfix] Saga recovery: sagas that failed before any step completed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ maintainers = [{name = "Vadim Kozyrevskiy", email = "vadikko2@mail.ru"}]
 name = "python-cqrs"
 readme = "README.md"
 requires-python = ">=3.10"
-version = "4.7.0"
+version = "4.7.1"
 
 [project.optional-dependencies]
 aiobreaker = ["aiobreaker>=0.3.0"]

--- a/src/cqrs/saga/compensation.py
+++ b/src/cqrs/saga/compensation.py
@@ -54,6 +54,14 @@ class SagaCompensator(typing.Generic[ContextT]):
         """
         await self._storage.update_status(self._saga_id, SagaStatus.COMPENSATING)
 
+        if not completed_steps:
+            logger.info(
+                f"Saga {self._saga_id}: completed_steps is empty, "
+                "skipping compensation (no step.compensate() will be called).",
+            )
+            await self._storage.update_status(self._saga_id, SagaStatus.FAILED)
+            return
+
         # Load history to skip already compensated steps
         history = await self._storage.get_step_history(self._saga_id)
         compensated_steps = {

--- a/src/cqrs/saga/saga.py
+++ b/src/cqrs/saga/saga.py
@@ -234,6 +234,14 @@ class SagaTransaction(typing.Generic[ContextT]):
                         for step in reconstructed_steps
                     ]
 
+                    if not self._completed_steps:
+                        logger.warning(
+                            f"Saga {self._saga_id}: no completed steps to compensate "
+                            "(saga failed before any step finished 'act', or step names in "
+                            "storage do not match saga step class names). "
+                            "Marking as FAILED without calling compensate().",
+                        )
+
                     # Immediately proceed to compensation - no forward execution
                     await self._compensate()
 

--- a/src/cqrs/saga/storage/memory.py
+++ b/src/cqrs/saga/storage/memory.py
@@ -123,7 +123,7 @@ class MemorySagaStorage(ISagaStorage):
         max_recovery_attempts: int = 5,
         stale_after_seconds: int | None = None,
     ) -> list[uuid.UUID]:
-        recoverable = (SagaStatus.RUNNING, SagaStatus.COMPENSATING, SagaStatus.FAILED)
+        recoverable = (SagaStatus.RUNNING, SagaStatus.COMPENSATING)
         now = datetime.datetime.now(datetime.timezone.utc)
         threshold = (
             (now - datetime.timedelta(seconds=stale_after_seconds))

--- a/src/cqrs/saga/storage/protocol.py
+++ b/src/cqrs/saga/storage/protocol.py
@@ -90,9 +90,10 @@ class ISagaStorage(abc.ABC):
                 updated). None means no staleness filter (backward compatible).
 
         Returns:
-            List of saga IDs (RUNNING, COMPENSATING, or FAILED), ordered by
-            updated_at ascending, with recovery_attempts < max_recovery_attempts,
-            and optionally updated_at older than the staleness threshold.
+            List of saga IDs (RUNNING or COMPENSATING only; FAILED sagas are
+            not included), ordered by updated_at ascending, with
+            recovery_attempts < max_recovery_attempts, and optionally
+            updated_at older than the staleness threshold.
         """
 
     @abc.abstractmethod

--- a/src/cqrs/saga/storage/sqlalchemy.py
+++ b/src/cqrs/saga/storage/sqlalchemy.py
@@ -321,7 +321,6 @@ class SqlAlchemySagaStorage(ISagaStorage):
         recoverable = (
             SagaStatus.RUNNING,
             SagaStatus.COMPENSATING,
-            SagaStatus.FAILED,
         )
         async with self.session_factory() as session:
             stmt = (

--- a/tests/integration/test_saga_storage_memory.py
+++ b/tests/integration/test_saga_storage_memory.py
@@ -172,7 +172,7 @@ class TestRecoveryMemory:
         storage: MemorySagaStorage,
         test_context: dict[str, str],
     ) -> None:
-        """Positive: returns RUNNING, COMPENSATING, FAILED sagas only."""
+        """Positive: returns RUNNING and COMPENSATING sagas only; FAILED excluded."""
         id1, id2, id3 = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
         for sid in (id1, id2, id3):
             await storage.create_saga(saga_id=sid, name="saga", context=test_context)
@@ -181,8 +181,9 @@ class TestRecoveryMemory:
         await storage.update_status(id3, SagaStatus.FAILED)
 
         ids = await storage.get_sagas_for_recovery(limit=10)
-        assert set(ids) == {id1, id2, id3}
-        assert len(ids) == 3
+        assert set(ids) == {id1, id2}
+        assert id3 not in ids
+        assert len(ids) == 2
 
     async def test_get_sagas_for_recovery_respects_limit(
         self,

--- a/tests/integration/test_saga_storage_sqlalchemy.py
+++ b/tests/integration/test_saga_storage_sqlalchemy.py
@@ -297,7 +297,7 @@ class TestRecoverySqlAlchemy:
         storage: SqlAlchemySagaStorage,
         test_context: dict[str, str],
     ) -> None:
-        """Positive: returns RUNNING, COMPENSATING, FAILED sagas only."""
+        """Positive: returns RUNNING and COMPENSATING sagas only; FAILED excluded."""
         id1, id2, id3 = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
         for sid in (id1, id2, id3):
             await storage.create_saga(saga_id=sid, name="saga", context=test_context)
@@ -306,8 +306,9 @@ class TestRecoverySqlAlchemy:
         await storage.update_status(id3, SagaStatus.FAILED)
 
         ids = await storage.get_sagas_for_recovery(limit=10)
-        assert set(ids) == {id1, id2, id3}
-        assert len(ids) == 3
+        assert set(ids) == {id1, id2}
+        assert id3 not in ids
+        assert len(ids) == 2
 
     async def test_get_sagas_for_recovery_respects_limit(
         self,


### PR DESCRIPTION
## Saga recovery: sagas that failed before any step completed

**Problem:** Sagas that failed on the first step (no steps with `act` + `COMPLETED` in the log) were still selected by the recovery task every run. For them, compensation was never executed (there were no completed steps to compensate), but they stayed in a "recoverable" state and were picked again on the next run, causing repeated "recovered" logs and unnecessary DB load.

**Changes:**

1. **Exclude FAILED sagas from recovery**  
   `get_sagas_for_recovery()` now returns only sagas in **RUNNING** or **COMPENSATING** status. Sagas already in **FAILED** are no longer returned, so they are not retried every minute.
   - Updated in: `SqlAlchemySagaStorage`, `MemorySagaStorage`, and the storage protocol docstring.

2. **Explicit handling when there are no steps to compensate**  
   When compensation runs with an empty list of completed steps (saga failed before completing any step):
   - **`compensation.py`**: At the start of `compensate_steps()`, if `completed_steps` is empty, the saga status is set to **FAILED**, a short info log is written, and the function returns (no `compensate()` calls).
   - **`saga.py`**: When recovering a saga in COMPENSATING/FAILED with no completed steps, a warning is logged that the saga failed before any step completed and is being marked FAILED without calling `compensate()`.

**Result:** Sagas that fail on the first step are marked FAILED once and no longer appear in recovery. Sagas that fail in the middle (e.g. external service down) continue to be recovered as RUNNING or COMPENSATING until compensation finishes or the saga is marked FAILED.

**Tests:** Integration tests for `get_sagas_for_recovery` now assert that only RUNNING and COMPENSATING sagas are returned, and that FAILED sagas are excluded.