### PR TITLE
[Feature] Fallbacks for requests and events handling

### DIFF
--- a/examples/cor_request_fallback.py
+++ b/examples/cor_request_fallback.py
@@ -1,0 +1,247 @@
+"""
+Example: Chain of Responsibility with Request Handler Fallback
+
+This example shows how to combine a COR (Chain of Responsibility) handler
+with RequestHandlerFallback. The primary handler is a RequestHandler that
+delegates to a COR chain; when the chain raises (e.g. downstream failure),
+the fallback handler is invoked.
+
+Use case: A request is first tried through a chain of handlers (e.g. try
+cache, then DB, then external API). If the whole chain fails (e.g. connection
+error), a fallback handler returns a default/cached response.
+
+================================================================================
+HOW TO RUN THIS EXAMPLE
+================================================================================
+
+Run the example:
+   python examples/cor_request_fallback.py
+
+The example will:
+- Send a command that is handled by a COR chain (primary path)
+- For source="error", the chain raises and fallback handler runs
+- For source="a" or "b", the chain handles the request successfully
+
+================================================================================
+WHAT THIS EXAMPLE DEMONSTRATES
+================================================================================
+
+1. RequestHandlerFallback with COR as primary:
+   - Primary is a RequestHandler that delegates to a COR chain (injected via DI).
+   - Fallback is a simple RequestHandler used when the chain raises.
+
+2. Building the chain:
+   - Create COR handler instances, build_chain(), then bind the chain entry
+     (first handler) in the container so the wrapper can receive it.
+
+3. Flow:
+   - mediator.send(request) dispatches to primary (CORChainWrapperHandler).
+   - Wrapper calls the chain; if the chain raises, dispatcher catches and
+     invokes fallback.
+
+4. Optional failure_exceptions:
+   - Restrict fallback to specific exception types (e.g. ConnectionError).
+
+================================================================================
+REQUIREMENTS
+================================================================================
+
+Make sure you have installed:
+   - cqrs (this package)
+   - di (dependency injection)
+
+================================================================================
+"""
+
+import asyncio
+import logging
+
+import di
+from di import dependent
+
+import cqrs
+from cqrs.requests import bootstrap
+from cqrs.requests.cor_request_handler import (
+    CORRequestHandler,
+    build_chain,
+)
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+HANDLER_SOURCE: list[str] = []  # "chain" or "fallback"
+
+
+# -----------------------------------------------------------------------------
+# Command and response
+# -----------------------------------------------------------------------------
+
+
+class FetchDataCommand(cqrs.Request):
+    source: str  # "a" | "b" | "error"
+
+
+class FetchDataResult(cqrs.Response):
+    data: str
+    source: str  # "chain" or "fallback"
+
+
+# -----------------------------------------------------------------------------
+# COR handlers (chain)
+# -----------------------------------------------------------------------------
+
+
+class SourceAHandler(CORRequestHandler[FetchDataCommand, FetchDataResult]):
+    @property
+    def events(self) -> list[cqrs.Event]:
+        return []
+
+    async def handle(self, request: FetchDataCommand) -> FetchDataResult | None:
+        if request.source == "a":
+            logger.info("COR chain: SourceAHandler handled source=a")
+            HANDLER_SOURCE.append("chain")
+            return FetchDataResult(data="data_from_a", source="chain")
+        return await self.next(request)
+
+
+class SourceBHandler(CORRequestHandler[FetchDataCommand, FetchDataResult]):
+    @property
+    def events(self) -> list[cqrs.Event]:
+        return []
+
+    async def handle(self, request: FetchDataCommand) -> FetchDataResult | None:
+        if request.source == "b":
+            logger.info("COR chain: SourceBHandler handled source=b")
+            HANDLER_SOURCE.append("chain")
+            return FetchDataResult(data="data_from_b", source="chain")
+        return await self.next(request)
+
+
+class DefaultChainHandler(CORRequestHandler[FetchDataCommand, FetchDataResult]):
+    """Last in chain: handles unknown or raises for source='error'."""
+
+    @property
+    def events(self) -> list[cqrs.Event]:
+        return []
+
+    async def handle(self, request: FetchDataCommand) -> FetchDataResult | None:
+        if request.source == "error":
+            logger.info("COR chain: DefaultChainHandler raising ConnectionError for source=error")
+            raise ConnectionError("Downstream service unavailable")
+        logger.info("COR chain: DefaultChainHandler handled (unknown source)")
+        HANDLER_SOURCE.append("chain")
+        return FetchDataResult(data="default_data", source="chain")
+
+
+# -----------------------------------------------------------------------------
+# Wrapper: RequestHandler that delegates to the COR chain
+# -----------------------------------------------------------------------------
+
+
+class CORChainWrapperHandler(
+    cqrs.RequestHandler[FetchDataCommand, FetchDataResult],
+):
+    """Primary 'handler' that runs the COR chain; chain is injected as the first link."""
+
+    def __init__(self, chain_entry: SourceAHandler) -> None:
+        self._chain_entry = chain_entry
+
+    @property
+    def events(self) -> list[cqrs.Event]:
+        return []
+
+    async def handle(self, request: FetchDataCommand) -> FetchDataResult:
+        result = await self._chain_entry.handle(request)
+        if result is None:
+            raise ValueError("COR chain did not handle the request")
+        return result
+
+
+# -----------------------------------------------------------------------------
+# Fallback handler (used when the chain raises)
+# -----------------------------------------------------------------------------
+
+
+class FallbackFetchDataHandler(
+    cqrs.RequestHandler[FetchDataCommand, FetchDataResult],
+):
+    @property
+    def events(self) -> list[cqrs.Event]:
+        return []
+
+    async def handle(self, request: FetchDataCommand) -> FetchDataResult:
+        logger.info("Fallback handler: returning cached/default for source=%s", request.source)
+        HANDLER_SOURCE.append("fallback")
+        return FetchDataResult(
+            data="cached_or_default",
+            source="fallback",
+        )
+
+
+# -----------------------------------------------------------------------------
+# Mappers and bootstrap
+# -----------------------------------------------------------------------------
+
+
+def commands_mapper(mapper: cqrs.RequestMap) -> None:
+    mapper.bind(
+        FetchDataCommand,
+        cqrs.RequestHandlerFallback(
+            primary=CORChainWrapperHandler,
+            fallback=FallbackFetchDataHandler,
+            failure_exceptions=(ConnectionError, TimeoutError),
+        ),
+    )
+
+
+async def main() -> None:
+    HANDLER_SOURCE.clear()
+
+    # Build COR chain and inject the chain entry so CORChainWrapperHandler gets it
+    source_a = SourceAHandler()
+    source_b = SourceBHandler()
+    default = DefaultChainHandler()
+    build_chain([source_a, source_b, default])
+
+    di_container = di.Container()
+    di_container.bind(
+        di.bind_by_type(
+            dependent.Dependent(lambda: source_a, scope="request"),
+            SourceAHandler,
+        ),
+    )
+
+    mediator = bootstrap.bootstrap(
+        di_container=di_container,
+        commands_mapper=commands_mapper,
+    )
+
+    print("\n" + "=" * 60)
+    print("COR REQUEST HANDLER FALLBACK EXAMPLE")
+    print("=" * 60)
+
+    # Case 1: chain handles (source=a)
+    print("\n1. Send FetchDataCommand(source='a') — chain handles")
+    result1: FetchDataResult = await mediator.send(FetchDataCommand(source="a"))
+    print(f"   Result: data={result1.data}, source={result1.source}")
+    assert result1.source == "chain" and result1.data == "data_from_a"
+
+    # Case 2: chain handles (source=b)
+    print("\n2. Send FetchDataCommand(source='b') — chain handles")
+    result2: FetchDataResult = await mediator.send(FetchDataCommand(source="b"))
+    print(f"   Result: data={result2.data}, source={result2.source}")
+    assert result2.source == "chain" and result2.data == "data_from_b"
+
+    # Case 3: chain raises (source=error) -> fallback runs
+    print("\n3. Send FetchDataCommand(source='error') — chain raises, fallback runs")
+    result3: FetchDataResult = await mediator.send(FetchDataCommand(source="error"))
+    print(f"   Result: data={result3.data}, source={result3.source}")
+    assert result3.source == "fallback" and result3.data == "cached_or_default"
+
+    print("\n   Handlers that ran (in order): " + str(HANDLER_SOURCE))
+    assert "chain" in HANDLER_SOURCE and "fallback" in HANDLER_SOURCE
+    print("\n" + "=" * 60 + "\n")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/event_fallback.py
+++ b/examples/event_fallback.py
@@ -1,0 +1,223 @@
+"""
+Example: Event Handler Fallback with Optional Circuit Breaker
+
+This example demonstrates the EventHandlerFallback pattern for domain event
+handlers. When the primary event handler fails (or the circuit breaker is open),
+the fallback handler is invoked. This is useful for resilient side effects
+such as sending notifications or updating read models when the primary path
+(e.g. external API) is unavailable.
+
+================================================================================
+HOW TO RUN THIS EXAMPLE
+================================================================================
+
+Run the example (without circuit breaker):
+   python examples/event_fallback.py
+
+With circuit breaker (optional dependency):
+   pip install aiobreaker
+   python examples/event_fallback.py
+
+The example will:
+- Execute a command that emits a domain event
+- Primary event handler fails (simulated external service failure)
+- Fallback event handler runs and completes successfully
+- With circuit breaker: after N failures the circuit opens and fallback is
+  used without calling the primary handler
+
+================================================================================
+WHAT THIS EXAMPLE DEMONSTRATES
+================================================================================
+
+1. EventHandlerFallback Registration:
+   - Bind event type to EventHandlerFallback(primary, fallback, ...)
+   - Optional failure_exceptions to trigger fallback only for specific errors
+   - Optional circuit_breaker (e.g. AioBreakerAdapter) per domain
+
+2. Primary and Fallback Handlers:
+   - Primary handler implements EventHandler[EventType]; can raise
+   - Fallback handler implements same event type; runs when primary fails
+
+3. Flow:
+   - Command handler emits domain event
+   - EventEmitter runs handlers; for EventHandlerFallback runs primary first
+   - On primary exception (or circuit open): fallback handler is invoked
+   - Events from the handler that actually ran are collected and returned
+
+4. Circuit Breaker (optional):
+   - Use one AioBreakerAdapter instance per domain (e.g. events)
+   - After fail_max failures, circuit opens; primary is not called, fallback runs
+
+================================================================================
+REQUIREMENTS
+================================================================================
+
+Make sure you have installed:
+   - cqrs (this package)
+   - di (dependency injection)
+
+Optional for circuit breaker:
+   pip install aiobreaker
+   or: pip install python-cqrs[aiobreaker]
+
+================================================================================
+"""
+
+import asyncio
+import logging
+import di
+
+import cqrs
+from cqrs.requests import bootstrap
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+# Track which handler ran for demo output
+EVENTS_HANDLED_BY: list[str] = []
+
+
+# -----------------------------------------------------------------------------
+# Command and domain event
+# -----------------------------------------------------------------------------
+
+
+class SendNotificationCommand(cqrs.Request):
+    user_id: str
+    message: str
+
+
+class NotificationSent(cqrs.DomainEvent, frozen=True):
+    user_id: str
+    message: str
+
+
+# -----------------------------------------------------------------------------
+# Command handler (emits domain event)
+# -----------------------------------------------------------------------------
+
+
+class SendNotificationCommandHandler(cqrs.RequestHandler[SendNotificationCommand, None]):
+    @property
+    def events(self) -> list[cqrs.Event]:
+        return self._events
+
+    def __init__(self) -> None:
+        self._events: list[cqrs.Event] = []
+
+    async def handle(self, request: SendNotificationCommand) -> None:
+        self._events.append(
+            NotificationSent(user_id=request.user_id, message=request.message),
+        )
+        logger.info("Command: emitted NotificationSent for user %s", request.user_id)
+
+
+# -----------------------------------------------------------------------------
+# Primary event handler (simulates failure – e.g. external notification API down)
+# -----------------------------------------------------------------------------
+
+
+class PrimaryNotificationSentHandler(cqrs.EventHandler[NotificationSent]):
+    async def handle(self, event: NotificationSent) -> None:
+        logger.info(
+            "Primary handler: would send notification to user %s: %s",
+            event.user_id,
+            event.message,
+        )
+        EVENTS_HANDLED_BY.append("primary")
+        raise RuntimeError("External notification service unavailable")
+
+
+# -----------------------------------------------------------------------------
+# Fallback event handler (e.g. write to local queue or log)
+# -----------------------------------------------------------------------------
+
+
+class FallbackNotificationSentHandler(cqrs.EventHandler[NotificationSent]):
+    async def handle(self, event: NotificationSent) -> None:
+        logger.info(
+            "Fallback handler: enqueue notification for user %s (primary failed): %s",
+            event.user_id,
+            event.message,
+        )
+        EVENTS_HANDLED_BY.append("fallback")
+
+
+# -----------------------------------------------------------------------------
+# Mappers and bootstrap
+# -----------------------------------------------------------------------------
+
+
+def command_mapper(mapper: cqrs.RequestMap) -> None:
+    mapper.bind(SendNotificationCommand, SendNotificationCommandHandler)
+
+
+def events_mapper(mapper: cqrs.EventMap) -> None:
+    # Without circuit breaker: any exception from primary triggers fallback
+    mapper.bind(
+        NotificationSent,
+        cqrs.EventHandlerFallback(
+            primary=PrimaryNotificationSentHandler,
+            fallback=FallbackNotificationSentHandler,
+        ),
+    )
+
+
+def events_mapper_with_circuit_breaker(mapper: cqrs.EventMap) -> None:
+    try:
+        from cqrs.adapters.circuit_breaker import AioBreakerAdapter
+    except ImportError:
+        # No aiobreaker: use same as without circuit breaker
+        events_mapper(mapper)
+        return
+
+    event_cb = AioBreakerAdapter(fail_max=2, timeout_duration=60)
+    mapper.bind(
+        NotificationSent,
+        cqrs.EventHandlerFallback(
+            primary=PrimaryNotificationSentHandler,
+            fallback=FallbackNotificationSentHandler,
+            circuit_breaker=event_cb,
+        ),
+    )
+
+
+async def main() -> None:
+    EVENTS_HANDLED_BY.clear()
+
+    use_circuit_breaker = False
+    try:
+        import aiobreaker  # noqa: F401
+
+        use_circuit_breaker = True
+    except ImportError:
+        pass
+
+    events_mapper_fn = events_mapper_with_circuit_breaker if use_circuit_breaker else events_mapper
+
+    mediator = bootstrap.bootstrap(
+        di_container=di.Container(),
+        commands_mapper=command_mapper,
+        domain_events_mapper=events_mapper_fn,
+    )
+
+    print("\n" + "=" * 60)
+    print("EVENT HANDLER FALLBACK EXAMPLE")
+    print("=" * 60)
+    print("\nSending command that emits NotificationSent...")
+    print("Primary handler will fail; fallback handler will run.\n")
+
+    await mediator.send(
+        SendNotificationCommand(user_id="user_1", message="Hello from CQRS"),
+    )
+
+    print("\nResult:")
+    print(f"  Handlers that ran (in order): {EVENTS_HANDLED_BY}")
+    assert "primary" in EVENTS_HANDLED_BY and "fallback" in EVENTS_HANDLED_BY
+    assert EVENTS_HANDLED_BY[-1] == "fallback"
+    print("  ✓ Primary ran and failed; fallback ran and completed.")
+    print("\n" + "=" * 60 + "\n")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/event_fallback.py
+++ b/examples/event_fallback.py
@@ -68,6 +68,7 @@ import logging
 import di
 
 import cqrs
+from cqrs.adapters.circuit_breaker import AioBreakerAdapter
 from cqrs.requests import bootstrap
 
 logging.basicConfig(level=logging.INFO)
@@ -165,13 +166,11 @@ def events_mapper(mapper: cqrs.EventMap) -> None:
 
 def events_mapper_with_circuit_breaker(mapper: cqrs.EventMap) -> None:
     try:
-        from cqrs.adapters.circuit_breaker import AioBreakerAdapter
+        event_cb = AioBreakerAdapter(fail_max=2, timeout_duration=60)
     except ImportError:
         # No aiobreaker: use same as without circuit breaker
         events_mapper(mapper)
         return
-
-    event_cb = AioBreakerAdapter(fail_max=2, timeout_duration=60)
     mapper.bind(
         NotificationSent,
         cqrs.EventHandlerFallback(

--- a/examples/request_fallback.py
+++ b/examples/request_fallback.py
@@ -65,6 +65,7 @@ import logging
 import di
 
 import cqrs
+from cqrs.adapters.circuit_breaker import AioBreakerAdapter
 from cqrs.requests import bootstrap
 
 logging.basicConfig(level=logging.INFO)
@@ -156,12 +157,10 @@ def commands_mapper(mapper: cqrs.RequestMap) -> None:
 
 def commands_mapper_with_circuit_breaker(mapper: cqrs.RequestMap) -> None:
     try:
-        from cqrs.adapters.circuit_breaker import AioBreakerAdapter
+        request_cb = AioBreakerAdapter(fail_max=2, timeout_duration=60)
     except ImportError:
         commands_mapper(mapper)
         return
-
-    request_cb = AioBreakerAdapter(fail_max=2, timeout_duration=60)
     mapper.bind(
         GetUserProfileCommand,
         cqrs.RequestHandlerFallback(

--- a/examples/request_fallback.py
+++ b/examples/request_fallback.py
@@ -1,0 +1,214 @@
+"""
+Example: Request Handler Fallback with Optional Circuit Breaker
+
+This example demonstrates the RequestHandlerFallback pattern for command/query
+handlers. When the primary request handler fails (or the circuit breaker is
+open), the fallback handler is invoked. This is useful for resilient reads
+or writes when the primary path (e.g. database or external API) is unavailable.
+
+================================================================================
+HOW TO RUN THIS EXAMPLE
+================================================================================
+
+Run the example (without circuit breaker):
+   python examples/request_fallback.py
+
+With circuit breaker (optional dependency):
+   pip install aiobreaker
+   python examples/request_fallback.py
+
+The example will:
+- Send a command that is handled by a primary handler (simulated to fail)
+- Fallback handler runs and returns a valid response
+- With circuit breaker: after N failures the circuit opens and requests are
+  dispatched to fallback without calling the primary handler
+
+================================================================================
+WHAT THIS EXAMPLE DEMONSTRATES
+================================================================================
+
+1. RequestHandlerFallback Registration:
+   - Bind request type to RequestHandlerFallback(primary, fallback, ...)
+   - Optional failure_exceptions to trigger fallback only for specific errors
+   - Optional circuit_breaker (e.g. AioBreakerAdapter) per domain
+
+2. Primary and Fallback Handlers:
+   - Both implement RequestHandler[Request, Response]
+   - Primary can raise; fallback provides alternative implementation (e.g. cache)
+
+3. Flow:
+   - mediator.send(request) dispatches to primary handler
+   - On primary exception (or circuit open): fallback handler is invoked
+   - Response and events from the handler that ran are returned
+
+4. Circuit Breaker (optional):
+   - Use one AioBreakerAdapter instance per domain (e.g. commands)
+   - After fail_max failures, circuit opens; primary is not called, fallback runs
+
+================================================================================
+REQUIREMENTS
+================================================================================
+
+Make sure you have installed:
+   - cqrs (this package)
+   - di (dependency injection)
+
+Optional for circuit breaker:
+   pip install aiobreaker
+   or: pip install python-cqrs[aiobreaker]
+
+================================================================================
+"""
+
+import asyncio
+import logging
+import di
+
+import cqrs
+from cqrs.requests import bootstrap
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+HANDLER_USED: list[str] = []
+
+
+# -----------------------------------------------------------------------------
+# Command and response
+# -----------------------------------------------------------------------------
+
+
+class GetUserProfileCommand(cqrs.Request):
+    user_id: str
+
+
+class UserProfileResult(cqrs.Response):
+    user_id: str
+    name: str
+    source: str  # "primary" or "fallback"
+
+
+# -----------------------------------------------------------------------------
+# Primary handler (simulates failure – e.g. database unavailable)
+# -----------------------------------------------------------------------------
+
+
+class PrimaryGetUserProfileHandler(
+    cqrs.RequestHandler[GetUserProfileCommand, UserProfileResult],
+):
+    @property
+    def events(self) -> list[cqrs.Event]:
+        return []
+
+    async def handle(
+        self,
+        request: GetUserProfileCommand,
+    ) -> UserProfileResult:
+        logger.info("Primary handler: fetching profile for user %s", request.user_id)
+        HANDLER_USED.append("primary")
+        raise ConnectionError("Database unavailable")
+
+
+# -----------------------------------------------------------------------------
+# Fallback handler (e.g. return cached or default data)
+# -----------------------------------------------------------------------------
+
+
+class FallbackGetUserProfileHandler(
+    cqrs.RequestHandler[GetUserProfileCommand, UserProfileResult],
+):
+    @property
+    def events(self) -> list[cqrs.Event]:
+        return []
+
+    async def handle(
+        self,
+        request: GetUserProfileCommand,
+    ) -> UserProfileResult:
+        logger.info(
+            "Fallback handler: returning cached/default profile for user %s",
+            request.user_id,
+        )
+        HANDLER_USED.append("fallback")
+        return UserProfileResult(
+            user_id=request.user_id,
+            name="Unknown User",
+            source="fallback",
+        )
+
+
+# -----------------------------------------------------------------------------
+# Mappers and bootstrap
+# -----------------------------------------------------------------------------
+
+
+def commands_mapper(mapper: cqrs.RequestMap) -> None:
+    # Without circuit breaker: fallback on any exception (or restrict with failure_exceptions)
+    mapper.bind(
+        GetUserProfileCommand,
+        cqrs.RequestHandlerFallback(
+            primary=PrimaryGetUserProfileHandler,
+            fallback=FallbackGetUserProfileHandler,
+            failure_exceptions=(ConnectionError, TimeoutError),
+        ),
+    )
+
+
+def commands_mapper_with_circuit_breaker(mapper: cqrs.RequestMap) -> None:
+    try:
+        from cqrs.adapters.circuit_breaker import AioBreakerAdapter
+    except ImportError:
+        commands_mapper(mapper)
+        return
+
+    request_cb = AioBreakerAdapter(fail_max=2, timeout_duration=60)
+    mapper.bind(
+        GetUserProfileCommand,
+        cqrs.RequestHandlerFallback(
+            primary=PrimaryGetUserProfileHandler,
+            fallback=FallbackGetUserProfileHandler,
+            failure_exceptions=(ConnectionError, TimeoutError),
+            circuit_breaker=request_cb,
+        ),
+    )
+
+
+async def main() -> None:
+    HANDLER_USED.clear()
+
+    use_circuit_breaker = False
+    try:
+        import aiobreaker  # noqa: F401
+
+        use_circuit_breaker = True
+    except ImportError:
+        pass
+
+    commands_mapper_fn = commands_mapper_with_circuit_breaker if use_circuit_breaker else commands_mapper
+
+    mediator = bootstrap.bootstrap(
+        di_container=di.Container(),
+        commands_mapper=commands_mapper_fn,
+    )
+
+    print("\n" + "=" * 60)
+    print("REQUEST HANDLER FALLBACK EXAMPLE")
+    print("=" * 60)
+    print("\nSending GetUserProfileCommand (primary will fail)...\n")
+
+    result: UserProfileResult = await mediator.send(
+        GetUserProfileCommand(user_id="user_42"),
+    )
+
+    print("\nResult:")
+    print(f"  Handlers that ran (in order): {HANDLER_USED}")
+    print(f"  Response: user_id={result.user_id}, name={result.name}, source={result.source}")
+    assert result.source == "fallback"
+    assert "primary" in HANDLER_USED and "fallback" in HANDLER_USED
+    assert HANDLER_USED[-1] == "fallback"
+    print("  ✓ Primary ran and failed; fallback ran and returned response.")
+    print("\n" + "=" * 60 + "\n")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/streaming_handler_fallback.py
+++ b/examples/streaming_handler_fallback.py
@@ -1,0 +1,193 @@
+"""
+Example: Streaming Request Handler Fallback
+
+This example demonstrates RequestHandlerFallback with StreamingRequestHandler.
+When the primary streaming handler fails (e.g. raises after yielding some items),
+the fallback streaming handler is used and its stream is consumed.
+
+Use case: Stream results from a primary source (e.g. live API); if the stream
+fails mid-way, switch to a fallback stream (e.g. cached or degraded results).
+
+================================================================================
+HOW TO RUN THIS EXAMPLE
+================================================================================
+
+Run the example:
+   python examples/streaming_handler_fallback.py
+
+The example will:
+- Start streaming from the primary handler (yields a few items then raises)
+- After the exception, the fallback streaming handler runs and yields items
+- Collect and print all results from both handlers
+
+================================================================================
+WHAT THIS EXAMPLE DEMONSTRATES
+================================================================================
+
+1. RequestHandlerFallback with streaming handlers:
+   - primary and fallback are both StreamingRequestHandler (async generators).
+   - Dispatcher runs primary.handle(request); if it raises, runs fallback.handle(request).
+
+2. Flow:
+   - mediator.stream(request) yields results from the primary handler.
+   - When the primary raises, the dispatcher catches and continues with the
+     fallback handler's stream.
+
+3. Optional failure_exceptions and circuit_breaker:
+   - Same as for non-streaming RequestHandlerFallback.
+
+================================================================================
+REQUIREMENTS
+================================================================================
+
+Make sure you have installed:
+   - cqrs (this package)
+   - di (dependency injection)
+
+================================================================================
+"""
+
+from collections.abc import AsyncIterator
+
+import asyncio
+import logging
+import typing
+
+import di
+
+import cqrs
+from cqrs.requests import bootstrap
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+STREAM_SOURCE: list[str] = []  # "primary" or "fallback" per yield
+
+
+# -----------------------------------------------------------------------------
+# Request and response (streaming)
+# -----------------------------------------------------------------------------
+
+
+class StreamItemsCommand(cqrs.Request):
+    item_ids: list[str]
+
+
+class StreamItemResult(cqrs.Response):
+    item_id: str
+    status: str
+    source: str  # "primary" or "fallback"
+
+
+# -----------------------------------------------------------------------------
+# Primary streaming handler (yields twice then raises)
+# -----------------------------------------------------------------------------
+
+
+class PrimaryStreamItemsHandler(
+    cqrs.StreamingRequestHandler[StreamItemsCommand, StreamItemResult],
+):
+    def __init__(self) -> None:
+        self._events: list[cqrs.Event] = []
+
+    @property
+    def events(self) -> list[cqrs.Event]:
+        return self._events.copy()
+
+    def clear_events(self) -> None:
+        self._events.clear()
+
+    async def handle(
+        self,
+        request: StreamItemsCommand,
+    ) -> AsyncIterator[StreamItemResult]:
+        for i, item_id in enumerate(request.item_ids):
+            if i >= 2:
+                logger.info("Primary streaming handler raising after 2 items")
+                raise ConnectionError("Stream connection lost")
+            STREAM_SOURCE.append("primary")
+            yield StreamItemResult(
+                item_id=item_id,
+                status="processed",
+                source="primary",
+            )
+
+
+# -----------------------------------------------------------------------------
+# Fallback streaming handler (yields all items)
+# -----------------------------------------------------------------------------
+
+
+class FallbackStreamItemsHandler(
+    cqrs.StreamingRequestHandler[StreamItemsCommand, StreamItemResult],
+):
+    def __init__(self) -> None:
+        self._events: list[cqrs.Event] = []
+
+    @property
+    def events(self) -> list[cqrs.Event]:
+        return self._events.copy()
+
+    def clear_events(self) -> None:
+        self._events.clear()
+
+    async def handle(
+        self,
+        request: StreamItemsCommand,
+    ) -> AsyncIterator[StreamItemResult]:
+        for item_id in request.item_ids:
+            STREAM_SOURCE.append("fallback")
+            yield StreamItemResult(
+                item_id=item_id,
+                status="from_fallback",
+                source="fallback",
+            )
+
+
+# -----------------------------------------------------------------------------
+# Mapper and bootstrap
+# -----------------------------------------------------------------------------
+
+
+def commands_mapper(mapper: cqrs.RequestMap) -> None:
+    mapper.bind(
+        StreamItemsCommand,
+        cqrs.RequestHandlerFallback(
+            primary=PrimaryStreamItemsHandler,
+            fallback=FallbackStreamItemsHandler,
+            failure_exceptions=(ConnectionError, TimeoutError),
+        ),
+    )
+
+
+async def main() -> None:
+    STREAM_SOURCE.clear()
+
+    mediator = bootstrap.bootstrap_streaming(
+        di_container=di.Container(),
+        commands_mapper=commands_mapper,
+    )
+
+    print("\n" + "=" * 60)
+    print("STREAMING HANDLER FALLBACK EXAMPLE")
+    print("=" * 60)
+    print("\nStreaming items (primary will fail after 2 items, then fallback runs)...\n")
+
+    request = StreamItemsCommand(item_ids=["id1", "id2", "id3", "id4"])
+    results: list[StreamItemResult] = []
+    async for response in mediator.stream(request):
+        if response is not None:
+            r = typing.cast(StreamItemResult, response)
+            results.append(r)
+            print(f"  Yield: item_id={r.item_id}, status={r.status}, source={r.source}")
+
+    print("\n   Handlers that yielded (in order): " + str(STREAM_SOURCE))
+    assert "primary" in STREAM_SOURCE and "fallback" in STREAM_SOURCE
+    assert results[0].source == "primary" and results[1].source == "primary"
+    assert any(r.source == "fallback" for r in results)
+    print("\n  ✓ Primary stream failed; fallback stream completed.")
+    print("=" * 60 + "\n")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ maintainers = [{name = "Vadim Kozyrevskiy", email = "vadikko2@mail.ru"}]
 name = "python-cqrs"
 readme = "README.md"
 requires-python = ">=3.10"
-version = "4.9.0"
+version = "4.10.0"
 
 [project.optional-dependencies]
 aiobreaker = ["aiobreaker>=0.3.0"]

--- a/src/cqrs/__init__.py
+++ b/src/cqrs/__init__.py
@@ -1,7 +1,9 @@
 from cqrs.compressors import Compressor, ZlibCompressor
 from cqrs.container.di import DIContainer
 from cqrs.container.protocol import Container
+from cqrs.circuit_breaker import ICircuitBreaker
 from cqrs.events import EventMap
+from cqrs.events.fallback import EventHandlerFallback
 from cqrs.events.event import (
     DCEvent,
     DCDomainEvent,
@@ -35,6 +37,7 @@ from cqrs.outbox.sqlalchemy import (
     SqlAlchemyOutboxedEventRepository,
 )
 from cqrs.producer import EventProducer
+from cqrs.requests.fallback import RequestHandlerFallback
 from cqrs.requests.map import RequestMap, SagaMap
 from cqrs.requests.mermaid import CoRMermaid
 from cqrs.requests.request import DCRequest, IRequest, PydanticRequest, Request
@@ -53,6 +56,9 @@ from cqrs.saga.step import (
 )
 
 __all__ = (
+    "ICircuitBreaker",
+    "EventHandlerFallback",
+    "RequestHandlerFallback",
     "RequestMediator",
     "SagaMediator",
     "StreamingRequestMediator",

--- a/src/cqrs/circuit_breaker.py
+++ b/src/cqrs/circuit_breaker.py
@@ -1,0 +1,53 @@
+"""Unified circuit breaker protocol for Saga, Request and Event fallbacks."""
+
+import typing
+
+
+class ICircuitBreaker(typing.Protocol):
+    """
+    Unified interface for circuit breaker implementations.
+
+    Used by Saga step fallbacks, Request handler fallbacks and Event handler
+    fallbacks. Each fallback type typically uses its own adapter instance;
+    the same adapter class works for all with identifier-based namespacing.
+
+    Attributes:
+        identifier: Handler/step type or string used as circuit breaker namespace.
+    """
+
+    async def call(
+        self,
+        identifier: type | str,
+        func: typing.Callable[..., typing.Awaitable[typing.Any]],
+        *args: typing.Any,
+        **kwargs: typing.Any,
+    ) -> typing.Any:
+        """
+        Execute the function with circuit breaker protection.
+
+        Args:
+            identifier: Handler/step type or string for breaker namespace.
+            func: The async function to execute.
+            *args: Positional arguments to pass to func.
+            **kwargs: Keyword arguments to pass to func.
+
+        Returns:
+            The result of func execution.
+
+        Raises:
+            CircuitBreakerError: If the circuit breaker is open.
+            Exception: Any exception raised by func (if circuit is closed).
+        """
+        ...
+
+    def is_circuit_breaker_error(self, exc: Exception) -> bool:
+        """
+        Check if the given exception is a circuit breaker error.
+
+        Args:
+            exc: The exception to check.
+
+        Returns:
+            True if the exception is a circuit breaker error, False otherwise.
+        """
+        ...

--- a/src/cqrs/circuit_breaker.py
+++ b/src/cqrs/circuit_breaker.py
@@ -8,11 +8,12 @@ class ICircuitBreaker(typing.Protocol):
     Unified interface for circuit breaker implementations.
 
     Used by Saga step fallbacks, Request handler fallbacks and Event handler
-    fallbacks. Each fallback type typically uses its own adapter instance;
-    the same adapter class works for all with identifier-based namespacing.
+    fallbacks. The same adapter class works for all with identifier-based
+    namespacing.
 
-    Attributes:
-        identifier: Handler/step type or string used as circuit breaker namespace.
+    Note:
+        Implementors should use a dedicated adapter instance per domain (events,
+        requests, saga) to keep circuit breaker state isolated.
     """
 
     async def call(
@@ -26,7 +27,7 @@ class ICircuitBreaker(typing.Protocol):
         Execute the function with circuit breaker protection.
 
         Args:
-            identifier: Handler/step type or string for breaker namespace.
+            identifier: Handler/step type or string used as circuit breaker namespace.
             func: The async function to execute.
             *args: Positional arguments to pass to func.
             **kwargs: Keyword arguments to pass to func.
@@ -51,3 +52,26 @@ class ICircuitBreaker(typing.Protocol):
             True if the exception is a circuit breaker error, False otherwise.
         """
         ...
+
+
+def should_use_fallback(
+    primary_error: Exception,
+    circuit_breaker: ICircuitBreaker | None,
+    failure_exceptions: tuple[type[Exception], ...],
+) -> bool:
+    """
+    Determine whether to invoke the fallback after primary handler failure.
+
+    Returns True if the circuit breaker reports a breaker error, or the
+    exception matches failure_exceptions, or failure_exceptions is empty
+    (any exception triggers fallback).
+    """
+    if circuit_breaker is not None and circuit_breaker.is_circuit_breaker_error(
+        primary_error,
+    ):
+        return True
+    if failure_exceptions and isinstance(primary_error, failure_exceptions):
+        return True
+    if not failure_exceptions:
+        return True
+    return False

--- a/src/cqrs/dispatcher/event.py
+++ b/src/cqrs/dispatcher/event.py
@@ -4,6 +4,7 @@ import typing
 from cqrs.container.protocol import Container
 from cqrs.events.event import IEvent
 from cqrs.events.event_handler import EventHandler
+from cqrs.events.fallback import EventHandlerFallback
 from cqrs.events.map import EventMap
 from cqrs.middlewares.base import MiddlewareChain
 
@@ -33,6 +34,53 @@ class EventDispatcher:
         for follow_up in handler.events:
             await self.dispatch(follow_up)
 
+    async def _handle_event_fallback(
+        self,
+        event: IEvent,
+        fallback_config: EventHandlerFallback,
+    ) -> None:
+        """Run primary handler with fallback on failure; dispatch follow-up events from the handler that ran."""
+        primary: _EventHandler = await self._container.resolve(fallback_config.primary)
+        try:
+            if fallback_config.circuit_breaker is not None:
+                await fallback_config.circuit_breaker.call(
+                    fallback_config.primary,
+                    primary.handle,
+                    event,
+                )
+            else:
+                await primary.handle(event)
+            for follow_up in primary.events:
+                await self.dispatch(follow_up)
+        except Exception as primary_error:
+            should_fallback = False
+            if fallback_config.circuit_breaker is not None and fallback_config.circuit_breaker.is_circuit_breaker_error(
+                primary_error,
+            ):
+                should_fallback = True
+            elif fallback_config.failure_exceptions and isinstance(
+                primary_error,
+                fallback_config.failure_exceptions,
+            ):
+                should_fallback = True
+            elif not fallback_config.failure_exceptions:
+                should_fallback = True
+            if should_fallback:
+                logger.warning(
+                    "Primary event handler %s failed: %s. Switching to fallback %s.",
+                    fallback_config.primary.__name__,
+                    primary_error,
+                    fallback_config.fallback.__name__,
+                )
+                fallback_handler: _EventHandler = await self._container.resolve(
+                    fallback_config.fallback,
+                )
+                await fallback_handler.handle(event)
+                for follow_up in fallback_handler.events:
+                    await self.dispatch(follow_up)
+            else:
+                raise primary_error
+
     async def dispatch(self, event: IEvent) -> None:
         handler_types = self._event_map.get(type(event), [])
         if not handler_types:
@@ -42,4 +90,7 @@ class EventDispatcher:
             )
             return
         for h_type in handler_types:
-            await self._handle_event(event, h_type)
+            if isinstance(h_type, EventHandlerFallback):
+                await self._handle_event_fallback(event, h_type)
+            else:
+                await self._handle_event(event, h_type)

--- a/src/cqrs/dispatcher/streaming.py
+++ b/src/cqrs/dispatcher/streaming.py
@@ -73,9 +73,7 @@ class StreamingRequestDispatcher:
         """
         handler_type = self._request_map.get(type(request), None)
         if handler_type is None:
-            raise RequestHandlerDoesNotExist(
-                f"StreamingRequestHandler not found matching Request type {type(request)}",
-            )
+            raise RequestHandlerDoesNotExist(f"StreamingRequestHandler not found matching Request type {type(request)}")
 
         if isinstance(handler_type, list):
             raise TypeError(
@@ -134,9 +132,7 @@ class StreamingRequestDispatcher:
             return
 
         handler_type_typed = typing.cast(typing.Type[StreamingRequestHandler], handler_type)
-        handler: StreamingRequestHandler = await self._container.resolve(
-            handler_type_typed,
-        )
+        handler: StreamingRequestHandler = await self._container.resolve(handler_type_typed)
 
         if not inspect.isasyncgenfunction(handler.handle):
             handler_name = (

--- a/src/cqrs/events/__init__.py
+++ b/src/cqrs/events/__init__.py
@@ -8,6 +8,7 @@ Public API:
 - :class:`EventEmitter` — sends domain events to handlers and notification events
   to a message broker.
 - :class:`EventMap` — registry of event type -> handler types; use :meth:`EventMap.bind`.
+- :class:`EventHandlerFallback` — fallback wrapper for event handlers with optional circuit breaker.
 """
 
 from cqrs.events.event import (
@@ -26,6 +27,7 @@ from cqrs.events.event import (
 )
 from cqrs.events.event_emitter import EventEmitter
 from cqrs.events.event_handler import EventHandler
+from cqrs.events.fallback import EventHandlerFallback
 from cqrs.events.map import EventMap
 
 __all__ = (
@@ -43,5 +45,6 @@ __all__ = (
     "PydanticNotificationEvent",
     "EventEmitter",
     "EventHandler",
+    "EventHandlerFallback",
     "EventMap",
 )

--- a/src/cqrs/events/event_emitter.py
+++ b/src/cqrs/events/event_emitter.py
@@ -5,6 +5,7 @@ import typing
 from cqrs import container as di_container, message_brokers
 from cqrs.events.event import IDomainEvent, IEvent, INotificationEvent
 from cqrs.events import event_handler, map
+from cqrs.events.fallback import EventHandlerFallback
 
 logger = logging.getLogger("cqrs")
 
@@ -110,6 +111,52 @@ class EventEmitter:
 
         await self._message_broker.send_message(message)
 
+    async def _handle_with_fallback(
+        self,
+        event: IDomainEvent,
+        fallback_config: EventHandlerFallback,
+    ) -> typing.Sequence[IEvent]:
+        """Run primary handler with fallback on failure; return events from the handler that ran."""
+        primary: _H = await self._container.resolve(fallback_config.primary)
+        try:
+            if fallback_config.circuit_breaker is not None:
+                await fallback_config.circuit_breaker.call(
+                    fallback_config.primary,
+                    primary.handle,
+                    event,
+                )
+            else:
+                await primary.handle(event)
+            return list(primary.events)
+        except Exception as primary_error:
+            should_fallback = False
+            if fallback_config.circuit_breaker is not None and fallback_config.circuit_breaker.is_circuit_breaker_error(
+                primary_error,
+            ):
+                logger.warning(
+                    "Circuit breaker open for event handler %s, switching to fallback %s",
+                    fallback_config.primary.__name__,
+                    fallback_config.fallback.__name__,
+                )
+                should_fallback = True
+            elif fallback_config.failure_exceptions:
+                if isinstance(primary_error, fallback_config.failure_exceptions):
+                    should_fallback = True
+            else:
+                should_fallback = True
+
+            if should_fallback:
+                logger.warning(
+                    "Primary event handler %s failed: %s. Switching to fallback %s.",
+                    fallback_config.primary.__name__,
+                    primary_error,
+                    fallback_config.fallback.__name__,
+                )
+                fallback_handler: _H = await self._container.resolve(fallback_config.fallback)
+                await fallback_handler.handle(event)
+                return list(fallback_handler.events)
+            raise primary_error
+
     @emit.register(IDomainEvent)
     async def _(self, event: IDomainEvent) -> typing.Sequence[IEvent]:
         """Emit domain event: run all registered handlers and return their follow-up events."""
@@ -121,17 +168,20 @@ class EventEmitter:
             )
             return ()
         follow_ups: list[IEvent] = []
-        for handler_type in handlers_types:
-            handler: _H = await self._container.resolve(
-                handler_type,
-            )
+        for handler_item in handlers_types:
+            if isinstance(handler_item, EventHandlerFallback):
+                follow_ups.extend(
+                    await self._handle_with_fallback(event, handler_item),
+                )
+                continue
+            handler_type = handler_item
+            handler: _H = await self._container.resolve(handler_type)
             logger.debug(
                 "Handling Event(%s) via event handler(%s)",
                 type(event).__name__,
                 handler_type.__name__,
             )
             await handler.handle(event)
-            # Snapshot follow-ups so shared handlers don't expose stale state
             follow_ups.extend(list(handler.events))
         return follow_ups
 

--- a/src/cqrs/events/fallback.py
+++ b/src/cqrs/events/fallback.py
@@ -1,0 +1,42 @@
+"""Fallback wrapper for event handlers with optional circuit breaker."""
+
+import dataclasses
+import typing
+
+from cqrs.circuit_breaker import ICircuitBreaker
+from cqrs.events import event_handler
+
+EventHandlerT = typing.Type[event_handler.EventHandler]
+
+
+@dataclasses.dataclass(frozen=True)
+class EventHandlerFallback:
+    """
+    Fallback wrapper for event handlers.
+
+    When the primary handler fails (or circuit breaker is open), the fallback
+    handler is invoked. Use a separate circuit breaker instance per domain
+    (e.g. one for events) that uses the same adapter class.
+
+    Attributes:
+        primary: The primary event handler class.
+        fallback: The fallback handler class to execute if primary fails.
+        failure_exceptions: Exception types that trigger fallback; if empty, any exception.
+        circuit_breaker: Optional circuit breaker instance (e.g. AioBreakerAdapter).
+
+    Example::
+        event_cb = AioBreakerAdapter(fail_max=5, timeout_duration=60)
+        event_map.bind(
+            OrderCreatedEvent,
+            EventHandlerFallback(
+                SendEmailHandler,
+                SendEmailFallbackHandler,
+                circuit_breaker=event_cb,
+            ),
+        )
+    """
+
+    primary: EventHandlerT
+    fallback: EventHandlerT
+    failure_exceptions: tuple[type[Exception], ...] = ()
+    circuit_breaker: ICircuitBreaker | None = None

--- a/src/cqrs/events/fallback.py
+++ b/src/cqrs/events/fallback.py
@@ -5,8 +5,15 @@ import typing
 
 from cqrs.circuit_breaker import ICircuitBreaker
 from cqrs.events import event_handler
+from cqrs.generic_utils import get_generic_args_for_origin
 
 EventHandlerT = typing.Type[event_handler.EventHandler]
+
+_EVENT_HANDLER_ORIGINS: tuple[type, ...] = (event_handler.EventHandler,)
+
+
+def _event_type_name(t: type) -> str:
+    return getattr(t, "__name__", str(t))
 
 
 @dataclasses.dataclass(frozen=True)
@@ -40,3 +47,46 @@ class EventHandlerFallback:
     fallback: EventHandlerT
     failure_exceptions: tuple[type[Exception], ...] = ()
     circuit_breaker: ICircuitBreaker | None = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.primary, type) or not isinstance(self.fallback, type):
+            raise TypeError(
+                "EventHandlerFallback primary and fallback must be handler classes",
+            )
+        if not issubclass(self.primary, event_handler.EventHandler):
+            raise TypeError(
+                f"EventHandlerFallback primary ({self.primary.__name__}) " "must be a subclass of EventHandler",
+            )
+        if not issubclass(self.fallback, event_handler.EventHandler):
+            raise TypeError(
+                f"EventHandlerFallback fallback ({self.fallback.__name__}) " "must be a subclass of EventHandler",
+            )
+        # Validate that primary and fallback handle the same event type
+        primary_args = get_generic_args_for_origin(
+            self.primary,
+            _EVENT_HANDLER_ORIGINS,
+            min_args=1,
+        )
+        fallback_args = get_generic_args_for_origin(
+            self.fallback,
+            _EVENT_HANDLER_ORIGINS,
+            min_args=1,
+        )
+        if primary_args is not None and fallback_args is not None:
+            # Reject TypeVar (unparameterized) so we only allow concrete types
+            if any(isinstance(a, typing.TypeVar) for a in primary_args + fallback_args):
+                raise TypeError(
+                    "EventHandlerFallback primary and fallback must be parameterized with a concrete event type "
+                    "(e.g. EventHandler[MyEvent])",
+                )
+            if primary_args[0] != fallback_args[0]:
+                raise TypeError(
+                    "EventHandlerFallback primary and fallback must handle the same event type: "
+                    f"primary {self.primary.__name__} handles {_event_type_name(primary_args[0])}, "
+                    f"fallback {self.fallback.__name__} handles {_event_type_name(fallback_args[0])}",
+                )
+        elif primary_args is None or fallback_args is None:
+            raise TypeError(
+                "EventHandlerFallback primary and fallback must be parameterized with a concrete event type "
+                "(e.g. EventHandler[MyEvent])",
+            )

--- a/src/cqrs/generic_utils.py
+++ b/src/cqrs/generic_utils.py
@@ -1,0 +1,43 @@
+"""Shared utilities for extracting generic type parameters from handler classes."""
+
+import typing
+
+
+def get_generic_args_for_origin(
+    klass: type,
+    origin_classes: tuple[type, ...],
+    min_args: int = 1,
+) -> tuple[type, ...] | None:
+    """
+    Extract generic type arguments from a class that inherits from a Generic base.
+
+    Walks __orig_bases__ and __bases__ to find the first base whose origin is
+    one of the given origin_classes, then returns typing.get_args(base).
+
+    Args:
+        klass: The handler class (e.g. a subclass of RequestHandler[Req, Res]).
+        origin_classes: Tuple of possible origin classes (e.g. (RequestHandler, StreamingRequestHandler)).
+        min_args: Minimum number of type arguments required to consider the result valid.
+
+    Returns:
+        Tuple of type arguments (e.g. (ReqT, ResT) or (ET,)), or None if not found
+        or if the base has fewer than min_args concrete arguments.
+    """
+    # Prefer __orig_bases__ (Python 3.12+ / generic subclass)
+    orig_bases = getattr(klass, "__orig_bases__", ())
+    for base in orig_bases:
+        origin = typing.get_origin(base)
+        if origin in origin_classes:
+            args = typing.get_args(base)
+            if len(args) >= min_args:
+                return args
+
+    # Fallback: __bases__ may contain the parameterized base
+    for base in klass.__bases__:
+        origin = typing.get_origin(base)
+        if origin in origin_classes:
+            args = typing.get_args(base)
+            if len(args) >= min_args:
+                return args
+
+    return None

--- a/src/cqrs/middlewares/base.py
+++ b/src/cqrs/middlewares/base.py
@@ -2,7 +2,7 @@ import functools
 import typing
 
 from cqrs.saga.models import SagaContext
-from cqrs.types import ReqT, ResT
+from cqrs.requests.request import ReqT, ResT
 
 HandleType = typing.Callable[[ReqT], typing.Awaitable[ResT] | ResT]
 

--- a/src/cqrs/requests/cor_request_handler.py
+++ b/src/cqrs/requests/cor_request_handler.py
@@ -5,7 +5,7 @@ import functools
 import typing
 
 from cqrs.events.event import IEvent
-from cqrs.types import ReqT, ResT
+from cqrs.requests.request import ReqT, ResT
 
 
 class CORRequestHandler(abc.ABC, typing.Generic[ReqT, ResT]):

--- a/src/cqrs/requests/fallback.py
+++ b/src/cqrs/requests/fallback.py
@@ -40,3 +40,16 @@ class RequestHandlerFallback:
     fallback: RequestHandlerT
     failure_exceptions: tuple[type[Exception], ...] = ()
     circuit_breaker: ICircuitBreaker | None = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.primary, type) or not isinstance(self.fallback, type):
+            raise TypeError(
+                "RequestHandlerFallback primary and fallback must be handler classes",
+            )
+        primary_streaming = issubclass(self.primary, StreamingRequestHandler)
+        fallback_streaming = issubclass(self.fallback, StreamingRequestHandler)
+        if primary_streaming != fallback_streaming:
+            raise TypeError(
+                "RequestHandlerFallback primary and fallback must be the same handler base type: "
+                "both RequestHandler or both StreamingRequestHandler",
+            )

--- a/src/cqrs/requests/fallback.py
+++ b/src/cqrs/requests/fallback.py
@@ -1,11 +1,19 @@
 """Fallback wrapper for request handlers with optional circuit breaker."""
 
 import dataclasses
+import typing
 
 from cqrs.circuit_breaker import ICircuitBreaker
+from cqrs.generic_utils import get_generic_args_for_origin
 from cqrs.requests.request_handler import RequestHandler, StreamingRequestHandler
 
 RequestHandlerT = type[RequestHandler] | type[StreamingRequestHandler]
+
+_REQUEST_HANDLER_ORIGINS: tuple[type, ...] = (RequestHandler, StreamingRequestHandler)
+
+
+def _type_name(t: type) -> str:
+    return getattr(t, "__name__", str(t))
 
 
 @dataclasses.dataclass(frozen=True)
@@ -52,4 +60,39 @@ class RequestHandlerFallback:
             raise TypeError(
                 "RequestHandlerFallback primary and fallback must be the same handler base type: "
                 "both RequestHandler or both StreamingRequestHandler",
+            )
+        # Validate that primary and fallback handle the same request and response types
+        primary_args = get_generic_args_for_origin(
+            self.primary,
+            _REQUEST_HANDLER_ORIGINS,
+            min_args=2,
+        )
+        fallback_args = get_generic_args_for_origin(
+            self.fallback,
+            _REQUEST_HANDLER_ORIGINS,
+            min_args=2,
+        )
+        if primary_args is not None and fallback_args is not None:
+            # Reject TypeVar (unparameterized) so we only allow concrete types
+            if any(isinstance(a, typing.TypeVar) for a in primary_args + fallback_args):
+                raise TypeError(
+                    "RequestHandlerFallback primary and fallback must be parameterized with concrete types "
+                    "(e.g. RequestHandler[MyCommand, MyResult] or StreamingRequestHandler[MyCommand, MyResult])",
+                )
+            if primary_args[0] != fallback_args[0]:
+                raise TypeError(
+                    "RequestHandlerFallback primary and fallback must handle the same request type: "
+                    f"primary {self.primary.__name__} handles {_type_name(primary_args[0])}, "
+                    f"fallback {self.fallback.__name__} handles {_type_name(fallback_args[0])}",
+                )
+            if primary_args[1] != fallback_args[1]:
+                raise TypeError(
+                    "RequestHandlerFallback primary and fallback must have the same response type: "
+                    f"primary {self.primary.__name__} returns {_type_name(primary_args[1])}, "
+                    f"fallback {self.fallback.__name__} returns {_type_name(fallback_args[1])}",
+                )
+        elif primary_args is None or fallback_args is None:
+            raise TypeError(
+                "RequestHandlerFallback primary and fallback must be parameterized with concrete types "
+                "(e.g. RequestHandler[MyCommand, MyResult] or StreamingRequestHandler[MyCommand, MyResult])",
             )

--- a/src/cqrs/requests/fallback.py
+++ b/src/cqrs/requests/fallback.py
@@ -1,0 +1,42 @@
+"""Fallback wrapper for request handlers with optional circuit breaker."""
+
+import dataclasses
+
+from cqrs.circuit_breaker import ICircuitBreaker
+from cqrs.requests.request_handler import RequestHandler, StreamingRequestHandler
+
+RequestHandlerT = type[RequestHandler] | type[StreamingRequestHandler]
+
+
+@dataclasses.dataclass(frozen=True)
+class RequestHandlerFallback:
+    """
+    Fallback wrapper for request handlers.
+
+    When the primary handler fails (or circuit breaker is open), the fallback
+    handler is invoked. Use a separate circuit breaker instance per domain
+    (e.g. one for requests) that uses the same adapter class.
+
+    Attributes:
+        primary: The primary request handler class.
+        fallback: The fallback handler class to execute if primary fails.
+        failure_exceptions: Exception types that trigger fallback; if empty, any exception.
+        circuit_breaker: Optional circuit breaker instance (e.g. AioBreakerAdapter).
+
+    Example::
+        request_cb = AioBreakerAdapter(fail_max=5, timeout_duration=60)
+        request_map.bind(
+            MyCommand,
+            RequestHandlerFallback(
+                MyCommandHandler,
+                MyCommandHandlerFallback,
+                failure_exceptions=(ConnectionError, TimeoutError),
+                circuit_breaker=request_cb,
+            ),
+        )
+    """
+
+    primary: RequestHandlerT
+    fallback: RequestHandlerT
+    failure_exceptions: tuple[type[Exception], ...] = ()
+    circuit_breaker: ICircuitBreaker | None = None

--- a/src/cqrs/requests/map.py
+++ b/src/cqrs/requests/map.py
@@ -1,6 +1,7 @@
 import typing
 
 from cqrs.requests.cor_request_handler import CORRequestHandler
+from cqrs.requests.fallback import RequestHandlerFallback
 from cqrs.requests.request import IRequest
 from cqrs.requests.request_handler import (
     RequestHandler,
@@ -12,7 +13,11 @@ from cqrs.saga.saga import Saga
 _KT = typing.TypeVar("_KT", bound=typing.Type[IRequest])
 
 # Type alias for handler types that can be bound to requests
-HandlerType = typing.Type[RequestHandler | StreamingRequestHandler] | typing.List[typing.Type[CORRequestHandler]]
+HandlerType = (
+    typing.Type[RequestHandler | StreamingRequestHandler]
+    | typing.List[typing.Type[CORRequestHandler]]
+    | RequestHandlerFallback
+)
 
 
 class RequestMap(typing.Dict[_KT, HandlerType]):

--- a/src/cqrs/requests/request.py
+++ b/src/cqrs/requests/request.py
@@ -1,8 +1,11 @@
 import abc
 import dataclasses
 import sys
+import typing
 
 import pydantic
+
+from cqrs.response import IResponse
 
 if sys.version_info >= (3, 11):
     from typing import Self  # novm
@@ -46,6 +49,12 @@ class IRequest(abc.ABC):
             A new instance of the request class.
         """
         raise NotImplementedError
+
+
+# Type variables for request/response (defined here to avoid circular import with
+# cqrs.types <-> cqrs.requests.request_handler). Re-exported from cqrs.types for compatibility.
+ReqT = typing.TypeVar("ReqT", bound=IRequest, contravariant=True)
+ResT = typing.TypeVar("ResT", bound=IResponse | None, covariant=True)
 
 
 @dataclasses.dataclass
@@ -140,4 +149,4 @@ class PydanticRequest(pydantic.BaseModel, IRequest):
 
 Request = PydanticRequest
 
-__all__ = ("Request", "IRequest", "DCRequest", "PydanticRequest")
+__all__ = ("Request", "IRequest", "DCRequest", "PydanticRequest", "ReqT", "ResT")

--- a/src/cqrs/requests/request_handler.py
+++ b/src/cqrs/requests/request_handler.py
@@ -2,7 +2,7 @@ import abc
 import typing
 
 from cqrs.events.event import IEvent
-from cqrs.types import ReqT, ResT
+from cqrs.requests.request import ReqT, ResT
 
 
 class RequestHandler(abc.ABC, typing.Generic[ReqT, ResT]):

--- a/src/cqrs/saga/execution.py
+++ b/src/cqrs/saga/execution.py
@@ -277,9 +277,9 @@ class FallbackStepExecutor(typing.Generic[ContextT]):
             # Execute primary step with circuit breaker if present
             if fallback_wrapper.circuit_breaker is not None:
                 step_result = await fallback_wrapper.circuit_breaker.call(
-                    step_type=fallback_wrapper.step,
-                    func=primary_step.act,
-                    context=self._context,
+                    fallback_wrapper.step,
+                    primary_step.act,
+                    self._context,
                 )
             else:
                 step_result = await primary_step.act(self._context)

--- a/src/cqrs/saga/fallback.py
+++ b/src/cqrs/saga/fallback.py
@@ -2,11 +2,11 @@
 
 import dataclasses
 
-from cqrs.saga.circuit_breaker import ISagaStepCircuitBreaker
+from cqrs.circuit_breaker import ICircuitBreaker
 from cqrs.saga.step import SagaStepHandler
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class Fallback:
     """
     Fallback wrapper for Saga steps.
@@ -32,4 +32,4 @@ class Fallback:
     step: type[SagaStepHandler]
     fallback: type[SagaStepHandler]
     failure_exceptions: tuple[type[Exception], ...] = ()
-    circuit_breaker: ISagaStepCircuitBreaker | None = None
+    circuit_breaker: ICircuitBreaker | None = None

--- a/src/cqrs/types.py
+++ b/src/cqrs/types.py
@@ -1,7 +1,11 @@
 """
 Type definitions for CQRS framework.
 
-This module re-exports common type variables (ReqT, ResT) and interfaces
-from cqrs.requests.request and cqrs.response for backward compatibility.
-Defining ReqT/ResT in request.py avoids circular import with request_handler.
+This module re-exports common type variables (ReqT, ResT) from
+cqrs.requests.request for backward compatibility. Defining ReqT/ResT in
+request.py avoids circular import with request_handler.
 """
+
+from cqrs.requests.request import ReqT, ResT
+
+__all__ = ("ReqT", "ResT")

--- a/src/cqrs/types.py
+++ b/src/cqrs/types.py
@@ -1,18 +1,7 @@
 """
 Type definitions for CQRS framework.
 
-This module contains common type variables used throughout the framework.
-It is placed at the bottom of the dependency hierarchy to avoid circular imports.
+This module re-exports common type variables (ReqT, ResT) and interfaces
+from cqrs.requests.request and cqrs.response for backward compatibility.
+Defining ReqT/ResT in request.py avoids circular import with request_handler.
 """
-
-import typing
-
-from cqrs.requests.request import IRequest
-from cqrs.response import IResponse
-
-# Type variable for request types (contravariant - can accept subtypes)
-ReqT = typing.TypeVar("ReqT", bound=IRequest, contravariant=True)
-
-# Type variable for response types (covariant - can return subtypes)
-# Can be IResponse or None
-ResT = typing.TypeVar("ResT", bound=IResponse | None, covariant=True)

--- a/tests/integration/test_pybreaker_adapter.py
+++ b/tests/integration/test_pybreaker_adapter.py
@@ -84,7 +84,7 @@ class TestAioBreakerAdapter:
 
         # Act
         result = await adapter.call(
-            step_type=step_type,
+            identifier=step_type,
             func=successful_function,
             value=5,
         )
@@ -103,14 +103,14 @@ class TestAioBreakerAdapter:
         for _ in range(2):
             with pytest.raises(RuntimeError):
                 await adapter.call(
-                    step_type=step_type_1,
+                    identifier=step_type_1,
                     func=failing_function,
                     error_type=RuntimeError,
                 )
 
         # Act - Step2 should still work (different namespace)
         result = await adapter.call(
-            step_type=step_type_2,
+            identifier=step_type_2,
             func=successful_function,
             value=3,
         )
@@ -121,7 +121,7 @@ class TestAioBreakerAdapter:
         # Act - Step1 circuit should still be closed (only 2 failures, need 3 to open)
         with pytest.raises(CircuitBreakerError):
             await adapter.call(
-                step_type=step_type_1,
+                identifier=step_type_1,
                 func=failing_function,
                 error_type=RuntimeError,
             )
@@ -129,7 +129,7 @@ class TestAioBreakerAdapter:
         # Now circuit should be open (3 failures reached)
         with pytest.raises(CircuitBreakerError):
             await adapter.call(
-                step_type=step_type_1,
+                identifier=step_type_1,
                 func=failing_function,
                 error_type=RuntimeError,
             )
@@ -162,7 +162,7 @@ class TestAioBreakerAdapter:
         for _ in range(3):
             try:
                 await adapter.call(
-                    step_type=step_type,
+                    identifier=step_type,
                     func=failing_function,
                     error_type=RuntimeError,
                 )
@@ -172,7 +172,7 @@ class TestAioBreakerAdapter:
         # Assert - Circuit should be open now
         with pytest.raises(CircuitBreakerError):
             await adapter.call(
-                step_type=step_type,
+                identifier=step_type,
                 func=failing_function,
                 error_type=RuntimeError,
             )
@@ -183,7 +183,7 @@ class TestAioBreakerAdapter:
         # Assert - Circuit should be half-open, trial call fails and circuit opens again
         with pytest.raises(CircuitBreakerError):
             await adapter.call(
-                step_type=step_type,
+                identifier=step_type,
                 func=failing_function,
                 error_type=RuntimeError,
             )
@@ -198,7 +198,7 @@ class TestAioBreakerAdapter:
         for _ in range(3):
             try:
                 await adapter.call(
-                    step_type=step_type,
+                    identifier=step_type,
                     func=failing_function,
                     error_type=RuntimeError,
                 )
@@ -208,7 +208,7 @@ class TestAioBreakerAdapter:
         # Act - Try to call when circuit is open
         try:
             await adapter.call(
-                step_type=step_type,
+                identifier=step_type,
                 func=failing_function,
                 error_type=RuntimeError,
             )
@@ -227,7 +227,7 @@ class TestAioBreakerAdapter:
         for _ in range(2):
             with pytest.raises(RuntimeError):
                 await adapter.call(
-                    step_type=step_type,
+                    identifier=step_type,
                     func=failing_function,
                     error_type=RuntimeError,
                 )
@@ -246,7 +246,7 @@ class TestAioBreakerAdapter:
         # Call 3 raises CircuitBreakerError (not RuntimeError)
         with pytest.raises(CircuitBreakerError):  # The 3rd failure
             await adapter.call(
-                step_type=step_type,
+                identifier=step_type,
                 func=failing_function,
                 error_type=RuntimeError,
             )
@@ -254,7 +254,7 @@ class TestAioBreakerAdapter:
         # Call 4 raises CircuitBreakerError
         with pytest.raises(CircuitBreakerError):
             await adapter.call(
-                step_type=step_type,
+                identifier=step_type,
                 func=failing_function,
                 error_type=RuntimeError,
             )
@@ -289,7 +289,7 @@ class TestAioBreakerAdapter:
             for _ in range(3):
                 with pytest.raises(BusinessException):
                     await adapter.call(
-                        step_type=step_type,
+                        identifier=step_type,
                         func=failing_function,
                         error_type=BusinessException,
                     )
@@ -298,7 +298,7 @@ class TestAioBreakerAdapter:
             # 1st failure
             with pytest.raises(NetworkException):
                 await adapter.call(
-                    step_type=step_type,
+                    identifier=step_type,
                     func=failing_function,
                     error_type=NetworkException,
                 )
@@ -306,7 +306,7 @@ class TestAioBreakerAdapter:
             # 2nd failure -> Open. Should raise CircuitBreakerError immediately
             with pytest.raises(CircuitBreakerError):
                 await adapter.call(
-                    step_type=step_type,
+                    identifier=step_type,
                     func=failing_function,
                     error_type=NetworkException,
                 )
@@ -314,7 +314,7 @@ class TestAioBreakerAdapter:
             # 3rd call -> CircuitBreakerError
             with pytest.raises(CircuitBreakerError):
                 await adapter.call(
-                    step_type=step_type,
+                    identifier=step_type,
                     func=failing_function,
                     error_type=NetworkException,
                 )
@@ -329,7 +329,7 @@ class TestAioBreakerAdapter:
         for _ in range(3):
             try:
                 await adapter.call(
-                    step_type=step_type,
+                    identifier=step_type,
                     func=failing_function,
                     error_type=RuntimeError,
                 )
@@ -339,7 +339,7 @@ class TestAioBreakerAdapter:
         # Verify open
         with pytest.raises(CircuitBreakerError):
             await adapter.call(
-                step_type=step_type,
+                identifier=step_type,
                 func=failing_function,
                 error_type=RuntimeError,
             )
@@ -347,7 +347,7 @@ class TestAioBreakerAdapter:
         # Concurrent calls should all fail fast
         tasks = [
             adapter.call(
-                step_type=step_type,
+                identifier=step_type,
                 func=failing_function,
                 error_type=RuntimeError,
             )

--- a/tests/unit/test_event_fallback.py
+++ b/tests/unit/test_event_fallback.py
@@ -1,0 +1,109 @@
+"""Tests for EventHandlerFallback (without circuit breaker)."""
+
+from collections.abc import Sequence
+from typing import Any, TypeVar
+
+import pytest
+
+from cqrs import EventHandlerFallback
+from cqrs.container.protocol import Container
+from cqrs.events.event import DomainEvent, IEvent
+from cqrs.events.event_emitter import EventEmitter
+from cqrs.events.event_handler import EventHandler
+from cqrs.events.map import EventMap
+
+T = TypeVar("T")
+
+
+class SampleEvent(DomainEvent, frozen=True):
+    """Event type for fallback tests (name avoids pytest collecting it as a test class)."""
+
+    id: str
+
+
+class PrimaryEventHandler(EventHandler[SampleEvent]):
+    def __init__(self) -> None:
+        self._evs: list[IEvent] = []
+        self.called = False
+
+    @property
+    def events(self) -> Sequence[IEvent]:
+        return self._evs.copy()
+
+    async def handle(self, event: SampleEvent) -> None:
+        self.called = True
+        raise RuntimeError("Primary failed")
+
+
+class FallbackEventHandler(EventHandler[SampleEvent]):
+    def __init__(self) -> None:
+        self._evs: list[IEvent] = []
+        self.called = False
+
+    @property
+    def events(self) -> Sequence[IEvent]:
+        return self._evs.copy()
+
+    async def handle(self, event: SampleEvent) -> None:
+        self.called = True
+
+
+class _TestEventContainer:
+    """Minimal container for event fallback tests; implements Container protocol."""
+
+    def __init__(self) -> None:
+        self._primary = PrimaryEventHandler()
+        self._fallback = FallbackEventHandler()
+        self._external_container: Any = None
+
+    @property
+    def external_container(self) -> Any:
+        return self._external_container
+
+    def attach_external_container(self, container: Any) -> None:
+        self._external_container = container
+
+    async def resolve(self, type_: type[T]) -> T:
+        if type_ is PrimaryEventHandler:
+            return self._primary  # type: ignore[return-value]
+        if type_ is FallbackEventHandler:
+            return self._fallback  # type: ignore[return-value]
+        raise KeyError(type_)
+
+
+@pytest.mark.asyncio
+async def test_event_fallback_no_cb_primary_fails_uses_fallback() -> None:
+    event_map: EventMap = EventMap()
+    event_map.bind(
+        SampleEvent,
+        EventHandlerFallback(PrimaryEventHandler, FallbackEventHandler),
+    )
+    container: Container[Any] = _TestEventContainer()
+    emitter = EventEmitter(event_map=event_map, container=container)
+
+    follow_ups = await emitter.emit(SampleEvent(id="e1"))
+
+    assert container._primary.called
+    assert container._fallback.called
+    assert follow_ups == []
+
+
+@pytest.mark.asyncio
+async def test_event_fallback_failure_exceptions_only_matching_triggers_fallback() -> None:
+    event_map = EventMap()
+    event_map.bind(
+        SampleEvent,
+        EventHandlerFallback(
+            PrimaryEventHandler,
+            FallbackEventHandler,
+            failure_exceptions=(ValueError,),
+        ),
+    )
+    container: Container[Any] = _TestEventContainer()
+    emitter = EventEmitter(event_map=event_map, container=container)
+
+    with pytest.raises(RuntimeError, match="Primary failed"):
+        await emitter.emit(SampleEvent(id="e1"))
+
+    assert container._primary.called
+    assert not container._fallback.called

--- a/tests/unit/test_request_fallback.py
+++ b/tests/unit/test_request_fallback.py
@@ -1,0 +1,113 @@
+"""Tests for RequestHandlerFallback (without circuit breaker)."""
+
+from typing import Any, TypeVar
+
+import pytest
+
+from cqrs import RequestHandlerFallback
+from cqrs.container.protocol import Container
+from cqrs.dispatcher import RequestDispatcher
+from cqrs.events.event import IEvent
+from cqrs.requests.map import RequestMap
+from cqrs.requests.request import Request
+from cqrs.requests.request_handler import RequestHandler
+from cqrs.response import Response
+
+T = TypeVar("T")
+
+
+class SimpleCommand(Request):
+    value: str
+
+
+class SimpleResult(Response):
+    value: str
+
+
+class PrimaryHandler(RequestHandler[SimpleCommand, SimpleResult]):
+    def __init__(self) -> None:
+        self._events: list[IEvent] = []
+        self.called = False
+
+    @property
+    def events(self) -> list[IEvent]:
+        return self._events.copy()
+
+    async def handle(self, request: SimpleCommand) -> SimpleResult:
+        self.called = True
+        raise RuntimeError("Primary failed")
+
+
+class FallbackHandler(RequestHandler[SimpleCommand, SimpleResult]):
+    def __init__(self) -> None:
+        self._events: list[IEvent] = []
+        self.called = False
+
+    @property
+    def events(self) -> list[IEvent]:
+        return self._events.copy()
+
+    async def handle(self, request: SimpleCommand) -> SimpleResult:
+        self.called = True
+        return SimpleResult(value=f"fallback:{request.value}")
+
+
+class _TestRequestContainer:
+    """Minimal container for request fallback tests; implements Container protocol."""
+
+    def __init__(self) -> None:
+        self._primary = PrimaryHandler()
+        self._fallback = FallbackHandler()
+        self._external_container: Any = None
+
+    @property
+    def external_container(self) -> Any:
+        return self._external_container
+
+    def attach_external_container(self, container: Any) -> None:
+        self._external_container = container
+
+    async def resolve(self, type_: type[T]) -> T:
+        if type_ is PrimaryHandler:
+            return self._primary  # type: ignore[return-value]
+        if type_ is FallbackHandler:
+            return self._fallback  # type: ignore[return-value]
+        raise KeyError(type_)
+
+
+@pytest.mark.asyncio
+async def test_request_fallback_no_cb_primary_fails_uses_fallback() -> None:
+    request_map: RequestMap = RequestMap()
+    request_map.bind(
+        SimpleCommand,
+        RequestHandlerFallback(PrimaryHandler, FallbackHandler),
+    )
+    container: Container[Any] = _TestRequestContainer()
+    dispatcher = RequestDispatcher(request_map=request_map, container=container)
+
+    result = await dispatcher.dispatch(SimpleCommand(value="x"))
+
+    assert result.response.value == "fallback:x"
+    assert container._primary.called
+    assert container._fallback.called
+
+
+@pytest.mark.asyncio
+async def test_request_fallback_failure_exceptions_only_matching_triggers_fallback() -> None:
+    request_map = RequestMap()
+    request_map.bind(
+        SimpleCommand,
+        RequestHandlerFallback(
+            PrimaryHandler,
+            FallbackHandler,
+            failure_exceptions=(ValueError,),
+        ),
+    )
+    container: Container[Any] = _TestRequestContainer()
+    dispatcher = RequestDispatcher(request_map=request_map, container=container)
+
+    with pytest.raises(RuntimeError, match="Primary failed"):
+        await dispatcher.dispatch(SimpleCommand(value="x"))
+
+    assert container._primary.called
+    assert not container._fallback.called


### PR DESCRIPTION
## ✨ Fallbacks for requests and events handling

> **TL;DR** — Request and event handler fallbacks with optional circuit breaker; unified `ICircuitBreaker` protocol; new examples and tests.

This release adds **fallback support** for request handlers and event handlers, with optional **circuit breaker** integration. You can now define primary and fallback handlers for commands, queries, streaming handlers, and domain events, and optionally protect them with a shared circuit breaker protocol.

---

## 🆕 What's new

### 📨 Request handler fallbacks

- **`RequestHandlerFallback`** — wrap a primary and fallback request handler so that when the primary fails (or the circuit is open), the fallback is used.
- Works with both **sync** `RequestHandler[Req, Res]` and **streaming** `StreamingRequestHandler[Req, Res]`.
- Optional **`failure_exceptions`** to trigger fallback only for specific exception types (e.g. `ConnectionError`, `TimeoutError`).
- Optional **circuit breaker** so that after N failures the primary is skipped and the fallback runs directly.

**Example:**

```python
from cqrs import RequestHandlerFallback
from cqrs.adapters.circuit_breaker import AioBreakerAdapter

request_cb = AioBreakerAdapter(fail_max=5, timeout_duration=60)
request_map.bind(
    GetOrderCommand,
    RequestHandlerFallback(
        GetOrderHandler,
        GetOrderFallbackHandler,
        failure_exceptions=(ConnectionError, TimeoutError),
        circuit_breaker=request_cb,
    ),
)
```

### 📢 Event handler fallbacks

- **`EventHandlerFallback`** — wrap a primary and fallback event handler so that when the primary fails (or the circuit is open), the fallback is used.
- Same options: **`failure_exceptions`** and optional **circuit breaker**.
- Supported in both **event dispatcher** and **event emitter** (handlers registered in `EventMap`).

**Example:**

```python
from cqrs import EventHandlerFallback

event_cb = AioBreakerAdapter(fail_max=5, timeout_duration=60)
event_map.bind(
    OrderCreatedEvent,
    EventHandlerFallback(
        SendEmailHandler,
        SendEmailFallbackHandler,
        circuit_breaker=event_cb,
    ),
)
```

### 🔌 Unified circuit breaker protocol

- **`ICircuitBreaker`** – a single protocol used by:
  - Saga step fallbacks (existing)
  - Request handler fallbacks (new)
  - Event handler fallbacks (new)
- **`AioBreakerAdapter`** now implements `ICircuitBreaker` (and still `ISagaStepCircuitBreaker` for backward compatibility).
- One adapter instance per “domain” (e.g. one for requests, one for events) is enough; each handler/step is namespaced by type.

### 📡 Streaming handlers

- **`RequestHandlerFallback`** is supported for **streaming** handlers: when the primary streaming handler fails, the fallback stream is used from the start (no resume from the same stream).

### 🛠️ Helpers

- **`get_generic_args_for_origin()`** in `cqrs.generic_utils` – used to validate that primary and fallback handlers handle the same request/event and (for requests) the same response type.
- **`should_use_fallback()`** in `cqrs.circuit_breaker` – central logic to decide whether to run the fallback after a primary failure (circuit open or exception in `failure_exceptions`, or any exception if `failure_exceptions` is empty).

---

## 📚 Documentation and examples

- **Examples added:**
  - `examples/request_fallback.py` – request handler fallback with optional circuit breaker
  - `examples/cor_request_fallback.py` – CoR (chain of responsibility) with fallback
  - `examples/event_fallback.py` – event handler fallback
  - `examples/streaming_handler_fallback.py` – streaming request handler fallback
- **Unit tests:** `test_request_fallback.py`, `test_event_fallback.py`; integration tests for the circuit breaker adapter updated.

---

## 📋 API summary

| Item | Description |
|------|-------------|
| **`cqrs.RequestHandlerFallback`** | Fallback wrapper for request/streaming handlers (primary, fallback, optional `failure_exceptions`, optional `circuit_breaker`). |
| **`cqrs.EventHandlerFallback`** | Fallback wrapper for event handlers (same options). |
| **`cqrs.ICircuitBreaker`** | Protocol: `call(identifier, func, *args, **kwargs)` and `is_circuit_breaker_error(exc)`. |
| **`cqrs.circuit_breaker.should_use_fallback`** | Helper to decide if fallback should run after primary error. |
| **`cqrs.generic_utils.get_generic_args_for_origin`** | Extract generic type args from handler classes (for validation). |

---

## ✅ Compatibility

- **Backward compatible:** Existing saga fallbacks and `AioBreakerAdapter` usage continue to work. `AioBreakerAdapter` now implements `ICircuitBreaker` in addition to `ISagaStepCircuitBreaker`.
- **Python:** 3.10+
- **Optional:** `aiobreaker` for circuit breaker support (`pip install python-cqrs[aiobreaker]`).

---