### PR TITLE
Add 'py.typed'

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ maintainers = [{name = "Vadim Kozyrevskiy", email = "vadikko2@mail.ru"}]
 name = "python-cqrs"
 readme = "README.md"
 requires-python = ">=3.10"
-version = "4.10.2"
+version = "4.10.3"
 
 [project.optional-dependencies]
 aiobreaker = ["aiobreaker>=0.3.0"]


### PR DESCRIPTION
Reasoning: https://peps.python.org/pep-0561/#packaging-type-information

Linters like pylance in strict mode would not check for types if either stubs (pyi) or py.typed are not provided

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bump to 4.10.3

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pypatterns/python-cqrs/pull/69?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->