### PR TITLE
Add python3.13 supporting

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python 3.12
+      - name: Set up Python 3.13
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ "3.10", "3.11", "3.12" ]
+        python-version: [ "3.10", "3.11", "3.12", "3.13" ]
 
     steps:
       - uses: actions/checkout@v4
@@ -28,6 +28,6 @@ jobs:
       - name: Build package
         run: python -m build
       - name: Publish package
-        if: success() && github.event_name == 'release' && matrix.python-version == '3.12'
+        if: success() && github.event_name == 'release' && matrix.python-version == '3.13'
         run: |
           twine upload dist/* --username __token__ --password ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v4
@@ -74,7 +74,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <h1>Python CQRS</h1>
   <p><strong>Event-Driven Architecture Framework for Distributed Systems</strong></p>
   <p>
-    <strong>Python 3.9+</strong> · Full documentation: <a href="https://mkdocs.python-cqrs.dev/">mkdocs.python-cqrs.dev</a>
+    <strong>Python 3.10+</strong> · Full documentation: <a href="https://mkdocs.python-cqrs.dev/">mkdocs.python-cqrs.dev</a>
   </p>
   <p>
     <a href="https://pypi.org/project/python-cqrs/">

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,8 @@ classifiers = [
   "Operating System :: OS Independent",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
-  "Programming Language :: Python :: 3.12"
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13"
 ]
 dependencies = [
   "dataclass-wizard==0.*",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ maintainers = [{name = "Vadim Kozyrevskiy", email = "vadikko2@mail.ru"}]
 name = "python-cqrs"
 readme = "README.md"
 requires-python = ">=3.10"
-version = "4.10.4"
+version = "4.11.0"
 
 [project.optional-dependencies]
 aiobreaker = ["aiobreaker>=0.3.0"]


### PR DESCRIPTION
## Python 3.13 Support

This release adds official support for **Python 3.13**. The minimum required version remains **Python 3.10+**.

### What's Changed

- Added PyPI classifier `Programming Language :: Python :: 3.13`
- Extended CI test matrix to Python 3.13 (lint, type checks, unit & integration tests)
- Updated release workflow to build on Python 3.10–3.13 and publish to PyPI from Python 3.13
- Switched CodSpeed benchmarks to Python 3.13
- Fixed README: minimum version is **3.10+** (was incorrectly listed as 3.9+)

### Supported Python Versions

| Version | Status |
|---------|--------|
| 3.10    | ✅ Supported |
| 3.11    | ✅ Supported |
| 3.12    | ✅ Supported |
| 3.13    | ✅ Supported (new) |

### Upgrade

No code changes or migration steps are required:

```bash
pip install -U python-cqrs
```

**Full Changelog**
Add Python 3.13 support
Update CI workflows (tests.yml, python-publish.yml, codspeed.yml)
Fix README minimum Python version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Python 3.13, including package publishing and benchmark compatibility.
* **Tests**
  * Expanded automated linting and test coverage to include Python 3.13.
* **Documentation**
  * Updated the documented minimum Python version to 3.10.
  * Added Python 3.13 to the supported-version listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->